### PR TITLE
Remove dictionary in hot path

### DIFF
--- a/ABCo.ABSave/ABSaveMap.cs
+++ b/ABCo.ABSave/ABSaveMap.cs
@@ -1,22 +1,30 @@
 ﻿using ABCo.ABSave.Configuration;
 using ABCo.ABSave.Converters;
+using ABCo.ABSave.Deserialization;
+using ABCo.ABSave.Helpers;
 using ABCo.ABSave.Mapping.Generation;
 using ABCo.ABSave.Mapping.Generation.General;
+using ABCo.ABSave.Serialization;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 
 namespace ABCo.ABSave.Mapping
 {
     public class ABSaveMap
     {
-        internal static ThreadLocal<MapGenerator> GeneratorPool = new ThreadLocal<MapGenerator>(() => new MapGenerator());
-        internal MapItemInfo RootItem;
+        internal static ThreadLocal<MapGenerator> _generatorPool = new ThreadLocal<MapGenerator>(() => new MapGenerator());
+        internal MapItemInfo _rootItem;
+        internal uint _highestConverterInstanceId;
+
+        readonly LightConcurrentPool<ABSaveSerializer> _serializerPool = new LightConcurrentPool<ABSaveSerializer>(2);
+        readonly LightConcurrentPool<ABSaveDeserializer> _deserializerPool = new LightConcurrentPool<ABSaveDeserializer>(2);
 
         /// <summary>
         /// All the types present throughout the map, and their respective map item.
         /// </summary>
-        internal Dictionary<Type, Converter?> AllTypes;
+        internal Dictionary<Type, Converter?> _allTypes;
 
         /// <summary>
         /// The configuration this map uses.
@@ -27,7 +35,7 @@ namespace ABCo.ABSave.Mapping
         internal ABSaveMap(ABSaveSettings settings)
         {
             Settings = settings;
-            AllTypes = new Dictionary<Type, Converter?>();
+            _allTypes = new Dictionary<Type, Converter?>();
         }
 
         public static ABSaveMap Get<T>(ABSaveSettings settings) => GetNonGeneric(typeof(T), settings);
@@ -37,7 +45,7 @@ namespace ABCo.ABSave.Mapping
             var map = new ABSaveMap(settings);
             MapGenerator? generator = map.GetGenerator();
 
-            map.RootItem = generator.GetMap(type);
+            map._rootItem = generator.GetMap(type);
             ReleaseGenerator(generator);
             return map;
         }
@@ -63,9 +71,11 @@ namespace ABCo.ABSave.Mapping
             return map;
         }
 
+        #region Generator Pooling
+
         internal MapGenerator GetGenerator()
         {
-            MapGenerator res = GeneratorPool.Value!;
+            MapGenerator res = _generatorPool.Value!;
             res.Initialize(this);
             return res;
         }
@@ -73,5 +83,33 @@ namespace ABCo.ABSave.Mapping
         // NOTE: It's generally not a good idea to call this from a "finally" just in case it pools
         // a generator that's been left in an invalid state.
         internal static void ReleaseGenerator(MapGenerator gen) => gen.FinishGeneration();
+
+        #endregion
+
+        #region Serializer Pooling
+
+        public ABSaveSerializer GetSerializer(Stream destStream, Dictionary<Type, uint>? targetVersions = null)
+        {
+            ABSaveSerializer serializer = _serializerPool.TryRent() ?? new ABSaveSerializer(this);
+            serializer.Initialize(destStream, targetVersions);
+            return serializer;
+        }
+
+        internal void ReleaseSerializer(ABSaveSerializer serializer) => _serializerPool.Release(serializer);
+
+        #endregion
+
+        #region Deserializer Pooling
+
+        public ABSaveDeserializer GetDeserializer(Stream destStream)
+        {
+            ABSaveDeserializer deserializer = _deserializerPool.TryRent() ?? new ABSaveDeserializer(this);
+            deserializer.Initialize(destStream);
+            return deserializer;
+        }
+
+        internal void ReleaseDeserializer(ABSaveDeserializer serializer) => _deserializerPool.Release(serializer);
+
+        #endregion
     }
 }

--- a/ABCo.ABSave/Converters/Converter.cs
+++ b/ABCo.ABSave/Converters/Converter.cs
@@ -16,6 +16,8 @@ namespace ABCo.ABSave.Converters
 
         internal volatile bool _isGenerating;
         internal bool _hasOneVersion;
+
+        internal uint _instanceId;
         internal uint _highestVersion;
 
         public uint HighestVersion => _highestVersion;

--- a/ABCo.ABSave/Deserialization/ABSaveDeserializer.Compressed.cs
+++ b/ABCo.ABSave/Deserialization/ABSaveDeserializer.Compressed.cs
@@ -4,7 +4,7 @@
     // NOTE: Full details about the "compressed numerical" structure can be seen in the TXT file: CompressedPlan.txt in the project root
     // ===============================================
     // This is just an implementation of everything shown there.
-    public partial class ABSaveDeserializer
+    public sealed partial class ABSaveDeserializer
     {
         public uint ReadCompressedInt()
         {

--- a/ABCo.ABSave/Mapping/Generation/MapGenerator.cs
+++ b/ABCo.ABSave/Mapping/Generation/MapGenerator.cs
@@ -137,7 +137,7 @@ namespace ABCo.ABSave.Mapping.Generation
         // we're going to wait (keep retrying again and again) until it's finally been allocated a place.
         //
         // This is represented by the item being null.
-        internal Converter? GetExistingOrAddNull(Type type) => MappingHelpers.GetExistingOrAddNull(_map.AllTypes, type);
+        internal Converter? GetExistingOrAddNull(Type type) => MappingHelpers.GetExistingOrAddNull(_map._allTypes, type);
 
         // Adds the current item to the dictionary and fills in its details.
         internal void ApplyItem(Converter item, Type type)
@@ -146,8 +146,11 @@ namespace ABCo.ABSave.Mapping.Generation
             item.IsValueItemType = type.IsValueType;
             item._isGenerating = true;
 
-            lock (_map.AllTypes)
-                _map.AllTypes[type] = item;
+            lock (_map._allTypes)
+            {
+                _map._allTypes[type] = item;
+                item._instanceId = _map._highestConverterInstanceId++;
+            }
         }
 
         static bool TryExpandNullable(ref Type expanded)

--- a/tests/ABCo.ABSave.TestConsole/TestObject.cs
+++ b/tests/ABCo.ABSave.TestConsole/TestObject.cs
@@ -22,30 +22,39 @@ namespace ABCo.ABSave.Testing.ConsoleApp
         }
 
         [Save(0)]
+        [Key(0)]
         public string Id { get; set; }
 
         [Save(1)]
+        [Key(1)]
         public string Type { get; set; }
 
         [Save(2)]
+        [Key(2)]
         public int Count { get; set; }
 
         [Save(3)]
+        [Key(3)]
         public DateTime CreationTime { get; set; }
 
         [Save(4)]
+        [Key(4)]
         public DateTime UpdateTime { get; set; }
 
         [Save(5)]
+        [Key(5)]
         public DateTime ExpirationTime { get; set; }
 
         [Save(6)]
+        [Key(6)]
         public string PreviousPageId { get; set; }
 
         [Save(7)]
+        [Key(7)]
         public string FollowingPageId { get; set; }
 
         [Save(8)]
+        [Key(8)]
         public List<ApiModelContainer> ModelContainers { get; set; }
 
         /// <inheritdoc/>
@@ -108,12 +117,15 @@ namespace ABCo.ABSave.Testing.ConsoleApp
     public sealed class ApiModelContainer : IEquatable<ApiModelContainer>
     {
         [Save(0)]
+        [Key(0)]
         public string Id { get; set; }
 
         [Save(1)]
+        [Key(1)]
         public string Type { get; set; }
 
         [Save(2)]
+        [Key(2)]
         public RestApiModel Model { get; set; }
 
         /// <inheritdoc/>
@@ -158,84 +170,111 @@ namespace ABCo.ABSave.Testing.ConsoleApp
     public sealed class RestApiModel : IEquatable<RestApiModel>
     {
         [Save(0)]
+        [Key(0)]
         public string Id { get; set; }
 
         [Save(1)]
+        [Key(1)]
         public string Type { get; set; }
 
         [Save(2)]
+        [Key(2)]
         public string Parent { get; set; }
 
         [Save(3)]
+        [Key(3)]
         public string Author { get; set; }
 
         [Save(4)]
+        [Key(4)]
         public string Title { get; set; }
 
         [Save(5)]
+        [Key(5)]
         public string Text { get; set; }
 
         [Save(6)]
+        [Key(6)]
         public string Url { get; set; }
 
         [Save(7)]
+        [Key(7)]
         public string HtmlContent { get; set; }
 
         [Save(8)]
+        [Key(8)]
         public int Upvotes { get; set; }
 
         [Save(9)]
+        [Key(9)]
         public int Downvotes { get; set; }
 
         [Save(10)]
+        [Key(10)]
         public float VotesRatio { get; set; }
 
         [Save(11)]
+        [Key(11)]
         public int Views { get; set; }
 
         [Save(12)]
+        [Key(12)]
         public int Clicks { get; set; }
 
         [Save(13)]
+        [Key(13)]
         public float ClicksRatio { get; set; }
 
         [Save(14)]
+        [Key(14)]
         public int NumberOfComments { get; set; }
 
         [Save(15)]
+        [Key(15)]
         public DateTime CreationTime { get; set; }
 
         [Save(16)]
+        [Key(16)]
         public DateTime UpdateTime { get; set; }
 
         [Save(17)]
+        [Key(17)]
         public DateTime ExpirationTime { get; set; }
 
         [Save(18)]
+        [Key(18)]
         public bool Flag1 { get; set; }
 
         [Save(19)]
+        [Key(19)]
         public bool Flag2 { get; set; }
 
         [Save(20)]
+        [Key(20)]
         public bool Flag3 { get; set; }
 
         [Save(21)]
+        [Key(21)]
         public bool Flag4 { get; set; }
 
         [Save(22)]
+        [Key(22)]
         public bool Flag5 { get; set; }
 
         [Save(23)]
+        [Key(23)]
         public string Optional1 { get; set; }
 
         [Save(24)]
+        [Key(24)]
         public string Optional2 { get; set; }
 
         [Save(25)]
+        [Key(25)]
         public string Optional3 { get; set; }
 
         [Save(26)]
+        [Key(26)]
         public MediaInfoModel Info { get; set; }
 
         /// <inheritdoc/>
@@ -354,15 +393,19 @@ namespace ABCo.ABSave.Testing.ConsoleApp
     public sealed class MediaInfoModel : IEquatable<MediaInfoModel>
     {
         [Save(0)]
+        [Key(0)]
         public string Id { get; set; }
 
         [Save(1)]
+        [Key(1)]
         public string AlbumUrl { get; set; }
 
         [Save(2)]
+        [Key(2)]
         public bool Property { get; set; }
 
         [Save(3)]
+        [Key(3)]
         public List<ImageModel> Images { get; set; }
 
         /// <inheritdoc/>
@@ -416,15 +459,19 @@ namespace ABCo.ABSave.Testing.ConsoleApp
     public sealed class ImageModel : IEquatable<ImageModel>
     {
         [Save(0)]
+        [Key(0)]
         public string Url { get; set; }
 
         [Save(1)]
+        [Key(1)]
         public int Width { get; set; }
 
         [Save(2)]
+        [Key(2)]
         public int Height { get; set; }
 
         [Save(3)]
+        [Key(3)]
         public float AspectRatio { get; set; }
 
         /// <inheritdoc/>

--- a/tests/ABCo.ABSave.UnitTests/Core/MainTests.cs
+++ b/tests/ABCo.ABSave.UnitTests/Core/MainTests.cs
@@ -151,8 +151,7 @@ namespace ABCo.ABSave.UnitTests.Core
             OtherTypeConverter.WritesToHeader = true;
             ResetStateWithMapFor<ClassWithMinVersion>();
             {
-                Serializer.Initialize(Stream, CurrentMap, 
-                    new Dictionary<System.Type, uint>() { { typeof(ClassWithMinVersion), 0 } });
+                Serializer = CurrentMap.GetSerializer(Stream, new Dictionary<System.Type, uint>() { { typeof(ClassWithMinVersion), 0 } });
 
                 // With version
                 Serializer.SerializeItem(new ClassWithMinVersion(), CurrentMapItem);
@@ -176,8 +175,7 @@ namespace ABCo.ABSave.UnitTests.Core
             OtherTypeConverter.WritesToHeader = false;
             ResetStateWithMapFor<ClassWithMinVersion>();
             {
-                Serializer.Initialize(Stream, CurrentMap,
-                    new Dictionary<System.Type, uint>() { { typeof(ClassWithMinVersion), 0 } });
+                Serializer = CurrentMap.GetSerializer(Stream, new Dictionary<System.Type, uint>() { { typeof(ClassWithMinVersion), 0 } });
 
                 // With version
                 Serializer.SerializeItem(new ClassWithMinVersion(), CurrentMapItem);

--- a/tests/ABCo.ABSave.UnitTests/Mapping/MapGeneratorTests.cs
+++ b/tests/ABCo.ABSave.UnitTests/Mapping/MapGeneratorTests.cs
@@ -43,7 +43,7 @@ namespace ABCo.ABSave.UnitTests.Mapping
         {
             Setup();
             Assert.IsNull(Generator.GetExistingOrAddNull(typeof(AllPrimitiveClass)));
-            Assert.IsNull(Map.AllTypes[typeof(AllPrimitiveClass)]);
+            Assert.IsNull(Map._allTypes[typeof(AllPrimitiveClass)]);
         }
 
         [TestMethod]
@@ -134,7 +134,7 @@ namespace ABCo.ABSave.UnitTests.Mapping
             Assert.IsNotNull(first ?? second);
 
             // Check that the item was created successfully.
-            Assert.IsInstanceOfType(Map.AllTypes[typeof(int)], typeof(EmptyConverter));
+            Assert.IsInstanceOfType(Map._allTypes[typeof(int)], typeof(EmptyConverter));
             ABSaveMap.ReleaseGenerator(secondGenerator);
         }
 

--- a/tests/ABCo.ABSave.UnitTests/TestHelpers/TestBase.cs
+++ b/tests/ABCo.ABSave.UnitTests/TestHelpers/TestBase.cs
@@ -32,11 +32,8 @@ namespace ABCo.ABSave.UnitTests.TestHelpers
             CurrentMap = ABSaveMap.Get<EmptyClass>(settings);
 
             Stream = new MemoryStream();
-            Serializer = new ABSaveSerializer();
-            Serializer.Initialize(Stream, CurrentMap, targetVersions);
-
-            Deserializer = new ABSaveDeserializer();
-            Deserializer.Initialize(Stream, CurrentMap);
+            Serializer = CurrentMap.GetSerializer(Stream, targetVersions);
+            Deserializer = CurrentMap.GetDeserializer(Stream);
         }
 
         public void GoToStart() => Stream.Position = 0;
@@ -147,8 +144,7 @@ namespace ABCo.ABSave.UnitTests.TestHelpers
             {
                 if (serializer == null)
                 {
-                    serializer = new ABSaveSerializer();
-                    serializer.Initialize(new MemoryStream(), CurrentMap, null);
+                    serializer = CurrentMap.GetSerializer(new MemoryStream());
                 }
                 else
                 {


### PR DESCRIPTION
Remove the dictionary in the hot path of ABSave, shown to in one case reduce ABSave from `3.8ms` to `2.8ms`